### PR TITLE
Update the call to match the updated signature

### DIFF
--- a/pubsub_consumer.go
+++ b/pubsub_consumer.go
@@ -126,7 +126,7 @@ func ensureSubscription(pubsubClient *pubsub.Client, topic *pubsub.Topic, subscr
 		log.Fatalf("Could not check if subscription exists: %v", err)
 	}
 	if !subscriptionExists {
-		new_subscription, err := pubsubClient.CreateSubscription(ctx, subscriptionName, topic, 0, nil)
+		new_subscription, err := pubsubClient.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{Topic: topic})
 		if err != nil {
 			log.Fatalf("Could not create PubSub subscription: %v", err)
 		}


### PR DESCRIPTION
When attempting to rebuild my dev environment I hit the error:

```
src/github.com/replaygaming/consumer/pubsub_consumer.go:129:59: too many arguments in call to pubsubClient.CreateSubscription
	have ("context".Context, string, *"cloud.google.com/go/pubsub".Topic, number, nil)
	want ("context".Context, string, "cloud.google.com/go/pubsub".SubscriptionConfig)
```

A bit of googling found the reason - https://github.com/GoogleCloudPlatform/google-cloud-go/commit/934866196d63fdcd8291ef6f16e70f4a830cda22

Thanks Google... :-/